### PR TITLE
fix(.github): Update CODEOWNERS with new GitHub usernames

### DIFF
--- a/.github/.CODEOWNERS
+++ b/.github/.CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*    @andgar2010
+*    @tech-andgar
 *    @andcan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.3] - 2024-05-03
+
+### Fixed - 3.3.3
+
+- Updated CODEOWNERS file to reflect changes in GitHub usernames for code owners.
+
 ## [3.3.2] - 2024-05-03
 
 ### Fixed - 3.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: http_status
 description: Constants enumerating the HTTP status codes in Dart. All status codes defined in RFC1945 (HTTP/1.0, RFC2616 (HTTP/1.1), and RFC2518 (WebDAV) are supported.
-version: 3.3.2
+version: 3.3.3
 repository: https://github.com/DartForge/http_status
 issue_tracker: https://github.com/DartForge/http_status/issues
 homepage: https://github.com/DartForge/http_status


### PR DESCRIPTION
Updated CODEOWNERS file to reflect changes in GitHub usernames for code owners. Added new username and removed old one.